### PR TITLE
MINOR BUGFIX: Ignore empty lines in config file

### DIFF
--- a/src/config_manager.c
+++ b/src/config_manager.c
@@ -428,7 +428,14 @@ static int config_manager_read_file(void)
 	configs.name = g_strsplit(contents, CONFIG_MANAGER_FILE_DELIM, MAX_CONFIGS);
 	
 	x=0;
-	while (configs.name[x] != NULL) x++;
+	while (configs.name[x] != NULL) {
+		if (configs.name[x][0]) {
+			x++;
+		} else {
+			configs.name[x] = NULL;
+			break;
+		}
+	}
 	configs.count = x;
 	config_manager_check_files();
 	if (configs.count > 0)


### PR DESCRIPTION
I was having some issues with blank lines, I think these were being created by a bug somewhere.
In any case, I thought the program should be a little more robust in handling the config file.
